### PR TITLE
javax.mail.Provider classes for the mocks

### DIFF
--- a/src/main/java/org/jvnet/mock_javamail/providers/IMAPMockStoreProvider.java
+++ b/src/main/java/org/jvnet/mock_javamail/providers/IMAPMockStoreProvider.java
@@ -1,0 +1,16 @@
+package org.jvnet.mock_javamail.providers;
+
+import org.jvnet.mock_javamail.MockStore;
+
+import javax.mail.Provider;
+
+/**
+ * Provider for the MockStore
+ */
+public class IMAPMockStoreProvider extends Provider {
+    public IMAPMockStoreProvider() {
+        super(Type.STORE, "imap", MockStore.class.getName(),
+                "java.net mock-javamail project", null);
+    }
+}
+

--- a/src/main/java/org/jvnet/mock_javamail/providers/POP3MockStoreProvider.java
+++ b/src/main/java/org/jvnet/mock_javamail/providers/POP3MockStoreProvider.java
@@ -1,0 +1,16 @@
+package org.jvnet.mock_javamail.providers;
+
+import org.jvnet.mock_javamail.MockStore;
+
+import javax.mail.Provider;
+
+/**
+ * Provider for the MockStore
+ */
+public class POP3MockStoreProvider extends Provider {
+    public POP3MockStoreProvider() {
+        super(Provider.Type.STORE, "pop3", MockStore.class.getName(),
+                "java.net mock-javamail project", null);
+    }
+}
+

--- a/src/main/java/org/jvnet/mock_javamail/providers/SMTPMockTransportProvider.java
+++ b/src/main/java/org/jvnet/mock_javamail/providers/SMTPMockTransportProvider.java
@@ -1,0 +1,15 @@
+package org.jvnet.mock_javamail.providers;
+
+import org.jvnet.mock_javamail.MockTransport;
+
+import javax.mail.Provider;
+
+/**
+ * Provider for the MockTransport
+ */
+public class SMTPMockTransportProvider extends Provider {
+    public SMTPMockTransportProvider() {
+        super(Provider.Type.TRANSPORT, "smtp", MockTransport.class.getName(),
+                "java.net mock-javamail project", null);
+    }
+}

--- a/src/main/resources/META-INF/services/javax.mail.Provider
+++ b/src/main/resources/META-INF/services/javax.mail.Provider
@@ -1,0 +1,3 @@
+org.jvnet.mock_javamail.providers.IMAPMockStoreProvider
+org.jvnet.mock_javamail.providers.SMTPMockTransportProvider
+org.jvnet.mock_javamail.providers.POP3MockStoreProvider


### PR DESCRIPTION
Motivation:

They no longer take priority over com.sun stores and transports
with Spring Boot 2.0.5